### PR TITLE
Fix a crash caused by define_method in a singleton

### DIFF
--- a/ext/backtracie_native_extension/backtracie.c
+++ b/ext/backtracie_native_extension/backtracie.c
@@ -260,7 +260,12 @@ static VALUE qualified_method_name_from_self(raw_location *the_location) {
           rb_str_concat(name, rb_funcall(the_class, to_s_id, 0));
           rb_str_concat(name, rb_str_new2("$singleton."));
         } else {
-          return SAFE_NAVIGATION(backtracie_rb_profile_frame_qualified_method_name, the_location->callable_method_entry);
+          if (backtracie_method_is_bmethod(the_location)) {
+            return qualified_method_name_for_block(the_location);
+          } else {
+            // rb_profile_frame_method_name & friends works with CFUNCs and ISEQ methods, but not BMETHODs
+            return backtracie_rb_profile_frame_qualified_method_name(the_location->callable_method_entry);
+          }
         }
       } else {
         rb_str_concat(name, rb_funcall(the_class, to_s_id, 0));

--- a/ext/backtracie_native_extension/ruby_shards.c
+++ b/ext/backtracie_native_extension/ruby_shards.c
@@ -319,6 +319,11 @@ bool backtracie_iseq_is_eval(raw_location *the_location) {
   return ((rb_iseq_t *) the_location->iseq)->body->type == ISEQ_TYPE_EVAL;
 }
 
+bool backtracie_method_is_bmethod(raw_location *the_location) {
+  return the_location->callable_method_entry &&
+    the_location->vm_method_type == VM_METHOD_TYPE_BMETHOD;
+}
+
 VALUE backtracie_refinement_name(raw_location *the_location) {
   VALUE defined_class = backtracie_defined_class(the_location);
   if (defined_class == Qnil) return Qnil;

--- a/ext/backtracie_native_extension/ruby_shards.h
+++ b/ext/backtracie_native_extension/ruby_shards.h
@@ -139,6 +139,7 @@ VALUE backtracie_called_id(raw_location *the_location);
 VALUE backtracie_defined_class(raw_location *the_location);
 bool backtracie_iseq_is_block(raw_location *the_location);
 bool backtracie_iseq_is_eval(raw_location *the_location);
+bool backtracie_method_is_bmethod(raw_location *the_location);
 VALUE backtracie_refinement_name(raw_location *the_location);
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
The rb_profile_frames stuff for some reason only knows how to get method names for CFUNC or ISEQ methods, but not BMETHOD methods. The test in this PR causes a crash without the patch to backtracie.c: https://gist.github.com/KJTsanaktsidis/20124991afac475e4149c172b8ebbf7e

This is because rb_profile_frame_method_name either calls `cframe(frame)` (which works if its' a `CFUNC),` or `frame2iseq(frame)` (which works for ISEQ); if neither of those work, it returns nil. The crash is then caused by passing nil to rb_str_concat.

Probably we should look to get this fixed in Ruby, but for now, patch around this by using the existing block path logic. It does lead to `{block}` being appended, but the test above it also has that, so I figured it'd be best to have it be consistent.