### PR TITLE
Add a "minimal" backtracie API that retains less stuff

### DIFF
--- a/ext/backtracie_native_extension/backtracie_frames.c
+++ b/ext/backtracie_native_extension/backtracie_frames.c
@@ -155,13 +155,16 @@
 // This is managed in backtracie.c
 extern VALUE backtracie_main_object_instance;
 extern VALUE backtracie_frame_wrapper_class;
-
+static void raw_location_to_minimal_location(const raw_location *raw_loc,
+                                             minimal_location_t *min_loc);
 static void mod_to_s_anon(VALUE klass, strbuilder_t *strout);
 static void mod_to_s_refinement(VALUE klass, strbuilder_t *strout);
 static void mod_to_s_singleton(VALUE klass, strbuilder_t *strout);
 static void mod_to_s(VALUE klass, strbuilder_t *strout);
-static void method_qualifier(const raw_location *loc, strbuilder_t *strout);
-static void method_name(const raw_location *loc, strbuilder_t *strout);
+static void minimal_location_method_qualifier(const minimal_location_t *loc,
+                                              strbuilder_t *strout);
+static void minimal_location_method_name(const minimal_location_t *loc,
+                                         strbuilder_t *strout);
 static bool frame_filename(const raw_location *loc, bool absolute,
                            strbuilder_t *strout);
 static bool iseq_path(const rb_iseq_t *iseq, bool absolute,
@@ -357,8 +360,10 @@ size_t backtracie_frame_name_cstr(const raw_location *loc, char *buf,
   strbuilder_t builder;
   strbuilder_init(&builder, buf, buflen);
 
-  method_qualifier(loc, &builder);
-  method_name(loc, &builder);
+  minimal_location_t min_loc;
+  raw_location_to_minimal_location(loc, &min_loc);
+  minimal_location_method_qualifier(&min_loc, &builder);
+  minimal_location_method_name(&min_loc, &builder);
 
   return builder.attempted_size;
 }
@@ -367,8 +372,10 @@ VALUE backtracie_frame_name_rbstr(const raw_location *loc) {
   strbuilder_t builder;
   strbuilder_init_growable(&builder, 256);
 
-  method_qualifier(loc, &builder);
-  method_name(loc, &builder);
+  minimal_location_t min_loc;
+  raw_location_to_minimal_location(loc, &min_loc);
+  minimal_location_method_qualifier(&min_loc, &builder);
+  minimal_location_method_name(&min_loc, &builder);
 
   VALUE ret = strbuilder_to_value(&builder);
   strbuilder_free_growable(&builder);
@@ -477,6 +484,50 @@ static int frame_label(const raw_location *loc, bool base,
   return 1;
 }
 
+static void raw_location_to_minimal_location(const raw_location *raw_loc,
+                                             minimal_location_t *min_loc) {
+
+  min_loc->is_ruby_frame = raw_loc->is_ruby_frame;
+  if (RTEST(raw_loc->callable_method_entry)) {
+    min_loc->method_name_contents = BACKTRACIE_METHOD_NAME_CONTENTS_CME_ID;
+    min_loc->method_name.cme_method_id =
+        ((rb_callable_method_entry_t *)raw_loc->callable_method_entry)
+            ->called_id;
+  } else if (RTEST(raw_loc->iseq)) {
+    min_loc->method_name_contents = BACKTRACIE_METHOD_NAME_CONTENTS_BASE_LABEL;
+    min_loc->method_name.base_label =
+        ((rb_iseq_t *)raw_loc->iseq)->body->location.base_label;
+  } else {
+    min_loc->method_name_contents = BACKTRACIE_METHOD_NAME_CONTENTS_BASE_LABEL;
+    min_loc->method_name.base_label = Qnil;
+  }
+
+  if (RTEST(raw_loc->iseq)) {
+    min_loc->has_iseq_type = 1;
+    min_loc->iseq_type = ((rb_iseq_t *)raw_loc->iseq)->body->type;
+    min_loc->line_number = calc_lineno((rb_iseq_t *)raw_loc->iseq, raw_loc->pc);
+  } else {
+    min_loc->has_iseq_type = 0;
+    min_loc->line_number = 0;
+  }
+
+  if (RTEST(raw_loc->self_is_real_self)) {
+    min_loc->method_qualifier_contents =
+        BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF;
+    min_loc->method_qualifier.self = raw_loc->self_or_self_class;
+  } else if (RTEST(raw_loc->callable_method_entry)) {
+    min_loc->method_qualifier_contents =
+        BACKTRACIE_METHOD_QUALIFIER_CONTENTS_CME_CLASS;
+    min_loc->method_qualifier.cme_defined_class =
+        ((rb_callable_method_entry_t *)raw_loc->callable_method_entry)
+            ->defined_class;
+  } else {
+    min_loc->method_qualifier_contents =
+        BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF_CLASS;
+    min_loc->method_qualifier.self_class = raw_loc->self_or_self_class;
+  }
+}
+
 static void mod_to_s_anon(VALUE klass, strbuilder_t *strout) {
   // Anonymous module/class - print the name of the first non-anonymous super.
   // something like "#{klazz.ancestors.map(&:name).compact.first}$anonymous"
@@ -561,59 +612,73 @@ static void mod_to_s(VALUE klass, strbuilder_t *strout) {
   strbuilder_append_value(strout, klass_name);
 }
 
-static void method_qualifier_impl(VALUE defined_class,
-                                  VALUE class_of_defined_class, VALUE self,
-                                  VALUE self_class, VALUE method_target,
-                                  strbuilder_t *strout) {
-  if (self == backtracie_main_object_instance) {
-    strbuilder_append(strout, "Object$<main>#");
-  } else if (self == rb_mRubyVMFrozenCore) {
-    strbuilder_append(strout, "RubyVM::FrozenCore#");
-  } else if (class_of_defined_class != Qundef &&
-             RTEST(class_of_defined_class) &&
-             FL_TEST(class_of_defined_class, RMODULE_IS_REFINEMENT)) {
-    // The method being called is defined on a refinement.
-    VALUE refinement_module = class_of_defined_class;
-    mod_to_s_refinement(refinement_module, strout);
-    strbuilder_append(strout, "#");
-  } else if (self != Qundef && class_or_module_or_iclass(self)) {
-    // Means the receiver itself is a module or class, i.e. we have
-    // SomeModule.foo
-    mod_to_s(self, strout);
-    strbuilder_append(strout, ".");
-  } else {
-    // Means the receiver is _not_ a module/class, so we print the name of the
-    // class that the method is defined on.
-    mod_to_s(method_target, strout);
-    strbuilder_append(strout, "#");
+static void minimal_location_method_qualifier(const minimal_location_t *loc,
+                                              strbuilder_t *strout) {
+  // First, check if it's a special object.
+  if (loc->method_qualifier_contents ==
+      BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF) {
+    if (loc->method_qualifier.self == backtracie_main_object_instance) {
+      strbuilder_append(strout, "Object$<main>#");
+      return;
+    }
+    if (loc->method_qualifier.self == rb_mRubyVMFrozenCore) {
+      strbuilder_append(strout, "RubyVM::FrozenCore#");
+      return;
+    }
   }
+
+  // Next, check if it's a refinement.
+  if (loc->method_qualifier_contents ==
+      BACKTRACIE_METHOD_QUALIFIER_CONTENTS_CME_CLASS) {
+    VALUE class_of_defined_class =
+        rb_class_of(loc->method_qualifier.cme_defined_class);
+    if (RTEST(class_of_defined_class) &&
+        FL_TEST(class_of_defined_class, RMODULE_IS_REFINEMENT)) {
+      // The method being called is defined on a refinement.
+      mod_to_s_refinement(class_of_defined_class, strout);
+      strbuilder_append(strout, "#");
+      return;
+    }
+  }
+
+  // Next, check if the method receiver is itself a class or module.
+  if (loc->method_qualifier_contents ==
+      BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF) {
+    if (class_or_module_or_iclass(loc->method_qualifier.self)) {
+      // We have something like SomeModule.foo being called directly like that,
+      // without an instance.
+      mod_to_s(loc->method_qualifier.self, strout);
+      strbuilder_append(strout, ".");
+      return;
+    }
+  }
+
+  // Means the method receiver is _not_ a module/class; so, print the name of
+  // the class that the method is defined on.
+  VALUE method_target;
+  switch (loc->method_qualifier_contents) {
+  case BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF:
+    method_target = rb_class_of(loc->method_qualifier.self);
+    break;
+  case BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF_CLASS:
+    method_target = loc->method_qualifier.self_class;
+    break;
+  case BACKTRACIE_METHOD_QUALIFIER_CONTENTS_CME_CLASS:
+    method_target = loc->method_qualifier.cme_defined_class;
+    break;
+  }
+
+  mod_to_s(method_target, strout);
+  strbuilder_append(strout, "#");
 }
 
-static void method_qualifier(const raw_location *loc, strbuilder_t *strout) {
-  rb_callable_method_entry_t *cme =
-      (rb_callable_method_entry_t *)loc->callable_method_entry;
-  VALUE defined_class = cme ? cme->defined_class : Qnil;
-  VALUE class_of_defined_class =
-      RTEST(defined_class) ? rb_class_of(defined_class) : Qnil;
-  VALUE self = loc->self_is_real_self ? loc->self_or_self_class : Qundef;
-  VALUE self_class = loc->self_is_real_self
-                         ? rb_class_of(loc->self_or_self_class)
-                         : loc->self_or_self_class;
-  VALUE method_target = RTEST(defined_class) ? defined_class : self_class;
-
-  method_qualifier_impl(defined_class, class_of_defined_class, self, self_class,
-                        method_target, strout);
-}
-
-static void method_name_impl(ID method_id, VALUE base_label,
-                             enum iseq_type iseq_type, VALUE self,
-                             strbuilder_t *strout) {
-
-  if (method_id) {
+static void minimal_location_method_name(const minimal_location_t *loc,
+                                         strbuilder_t *strout) {
+  if (loc->method_name_contents == BACKTRACIE_METHOD_NAME_CONTENTS_CME_ID) {
     // With a callable method entry, things are simple; just use that.
-    VALUE method_name = rb_id2str(method_id);
+    VALUE method_name = rb_id2str(loc->method_name.cme_method_id);
     strbuilder_append_value(strout, method_name);
-    if (iseq_type_is_block_or_eval(iseq_type)) {
+    if (loc->has_iseq_type && iseq_type_is_block_or_eval(loc->iseq_type)) {
       strbuilder_append(strout, "{block}");
     }
   } else {
@@ -622,49 +687,30 @@ static void method_name_impl(ID method_id, VALUE base_label,
     // fact, using the iseq->base_label is pretty much a last resort. If we
     // manage to write _anything_ else in our backtrace, we won't use it.
     bool did_write_anything = false;
-    if (self != Qundef) {
-      if (RB_TYPE_P(self, T_CLASS)) {
+    if (loc->method_qualifier_contents ==
+        BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF) {
+      if (RB_TYPE_P(loc->method_qualifier.self, T_CLASS)) {
         // No CME, and self being a class/module, means we're executing code
         // inside a class Foo; ...; end;
         strbuilder_append(strout, "{class exec}");
         did_write_anything = true;
       }
-      if (RB_TYPE_P(self, T_MODULE)) {
+      if (RB_TYPE_P(loc->method_qualifier.self, T_MODULE)) {
         strbuilder_append(strout, "{module exec}");
         did_write_anything = true;
       }
     }
-    if (iseq_type_is_block_or_eval(iseq_type)) {
+    if (loc->has_iseq_type && iseq_type_is_block_or_eval(loc->iseq_type)) {
       strbuilder_append(strout, "{block}");
       did_write_anything = true;
     }
     if (!did_write_anything) {
       // As a fallback, use whatever is on the base_label.
-      if (base_label != Qundef && RTEST(base_label)) {
-        strbuilder_append_value(strout, base_label);
-      } else {
-        BACKTRACIE_ASSERT_FAIL("backtracie: don't know how to set method name");
-      }
+      // n.b. method_name_contents is guaranteed to be set to
+      // CONTENTS_BASE_LABEL in this branch.
+      strbuilder_append_value(strout, loc->method_name.base_label);
     }
   }
-}
-
-static void method_name(const raw_location *loc, strbuilder_t *strout) {
-  rb_callable_method_entry_t *cme = NULL;
-  rb_iseq_t *iseq = NULL;
-  if (RTEST(loc->callable_method_entry)) {
-    cme = (rb_callable_method_entry_t *)loc->callable_method_entry;
-  }
-  if (RTEST(loc->iseq)) {
-    iseq = (rb_iseq_t *)loc->iseq;
-  }
-
-  ID method_id = cme ? cme->called_id : 0;
-  VALUE base_label = iseq ? iseq->body->location.base_label : Qundef;
-  enum iseq_type iseq_type = iseq ? iseq->body->type : 0;
-  VALUE self = loc->self_is_real_self ? loc->self_or_self_class : Qundef;
-
-  method_name_impl(method_id, base_label, iseq_type, self, strout);
 }
 
 // This is mostly a reimplementation of pathobj_path from vm_core.h
@@ -850,83 +896,9 @@ bool backtracie_capture_minimal_frame_for_thread(VALUE thread, int frame_index,
   if (!ret) {
     return ret;
   }
-
-  loc->is_ruby_frame = raw_loc.is_ruby_frame;
-
-  loc->has_cme_method_id = RTEST(raw_loc.callable_method_entry) ? 1 : 0;
-  if (RTEST(raw_loc.callable_method_entry)) {
-    loc->method_name.cme_method_id =
-        ((rb_callable_method_entry_t *)raw_loc.callable_method_entry)
-            ->def->original_id;
-  } else if (RTEST(raw_loc.iseq)) {
-    loc->method_name.base_label =
-        ((rb_iseq_t *)raw_loc.iseq)->body->location.base_label;
-  } else {
-    loc->method_name.base_label = Qnil;
-  }
-
-  if (RTEST(raw_loc.iseq)) {
-    loc->has_iseq_type = 1;
-    loc->iseq_type = ((rb_iseq_t *)raw_loc.iseq)->body->type;
-    loc->line_number = calc_lineno((rb_iseq_t *)raw_loc.iseq, raw_loc.pc);
-  } else {
-    loc->has_iseq_type = 0;
-    loc->line_number = 0;
-  }
-
-  if (RTEST(raw_loc.callable_method_entry)) {
-    loc->method_qualifier_contents = 2;
-    loc->method_qualifier =
-        ((rb_callable_method_entry_t *)raw_loc.callable_method_entry)
-            ->defined_class;
-  } else if (raw_loc.self_is_real_self) {
-    loc->method_qualifier_contents = 1;
-    loc->method_qualifier = raw_loc.self_or_self_class;
-  } else {
-    loc->method_qualifier_contents = 0;
-    loc->method_qualifier = raw_loc.self_or_self_class;
-  }
+  raw_location_to_minimal_location(&raw_loc, loc);
 
   return ret;
-}
-
-static void method_qualifier_minimal(const minimal_location_t *loc,
-                                     strbuilder_t *strout) {
-  VALUE defined_class = Qundef;
-  VALUE class_of_defined_class = Qundef;
-  VALUE self = Qundef;
-  VALUE self_class = Qundef;
-  VALUE method_target = Qundef;
-
-  if (loc->method_qualifier_contents == 2) {
-    // method_qualifier contains the cme->defined_class
-    defined_class = loc->method_qualifier;
-    class_of_defined_class = rb_class_of(defined_class);
-    method_target = defined_class;
-  } else if (loc->method_qualifier_contents == 1) {
-    // method qualifier contains the real self object.
-    self = loc->method_qualifier;
-    self_class = rb_class_of(self);
-    method_target = self_class;
-  } else if (loc->method_qualifier_contents == 0) {
-    // method qualifier contains the class of the self object.
-    self_class = loc->method_qualifier;
-    method_target = self_class;
-  }
-  method_qualifier_impl(defined_class, class_of_defined_class, self, self_class,
-                        method_target, strout);
-}
-
-static void method_name_minimal(const minimal_location_t *loc,
-                                strbuilder_t *strout) {
-  ID method_id = loc->has_cme_method_id ? loc->method_name.cme_method_id : 0;
-  VALUE base_label =
-      loc->has_cme_method_id ? Qundef : loc->method_name.base_label;
-  enum iseq_type iseq_type = loc->has_iseq_type ? loc->iseq_type : 0;
-  VALUE self =
-      loc->method_qualifier_contents == 1 ? loc->method_qualifier : Qundef;
-
-  method_name_impl(method_id, base_label, iseq_type, self, strout);
 }
 
 size_t backtracie_minimal_frame_name_cstr(const minimal_location_t *loc,
@@ -934,8 +906,8 @@ size_t backtracie_minimal_frame_name_cstr(const minimal_location_t *loc,
 
   strbuilder_t builder;
   strbuilder_init(&builder, buf, buflen);
-  method_qualifier_minimal(loc, &builder);
-  method_name_minimal(loc, &builder);
+  minimal_location_method_qualifier(loc, &builder);
+  minimal_location_method_name(loc, &builder);
   return builder.attempted_size;
 }
 

--- a/ext/backtracie_native_extension/public/backtracie.h
+++ b/ext/backtracie_native_extension/public/backtracie.h
@@ -184,22 +184,35 @@ int *backtracie_frame_wrapper_len(VALUE wrapper);
 // whole lot of memory, but only a small amount of those things are actually
 // needed to compute the method name.
 
+// These values define union descriminator values for minimal_location_t.
+// It's tempting to make this an enum, but apparently an enum in a bitfield is
+// implementation-defined behaviour.
+static const uint16_t BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF = 0;
+static const uint16_t BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF_CLASS = 1;
+static const uint16_t BACKTRACIE_METHOD_QUALIFIER_CONTENTS_CME_CLASS = 2;
+static const uint16_t BACKTRACIE_METHOD_NAME_CONTENTS_CME_ID = 0;
+static const uint16_t BACKTRACIE_METHOD_NAME_CONTENTS_BASE_LABEL = 1;
+
 typedef struct {
   // 1 -> ruby frame / 0 -> cfunc frame
   uint16_t is_ruby_frame : 1;
-  // What is in the method_quaalifier field?
-  // 0 -> rb_class_of(the VALUE the method was called on)
-  // 1 -> the VALUE the method was called on
-  // 2 -> the class that the callable_method_entry is defined on.
+  // What is in the method_qualifier field?
+  // 0 -> self
+  // 1 -> self_class
+  // 2 -> cme_defined_class
   uint16_t method_qualifier_contents : 2;
-  // 1 means the "method name" union contains a CME method ID, 0 means it
-  // contains a frame base_label.
-  uint16_t has_cme_method_id : 1;
+  // 0 -> cme_method_id
+  // 1 -> base_label
+  uint16_t method_name_contents : 1;
   // 1 means iseq_type is populated
   uint16_t has_iseq_type : 1;
 
   // Comes from iseq->body->type; is an iseq_type enum.
-  uint16_t iseq_type;
+  // 5 bits is _way_ more than enough to store this enum.
+  uint16_t iseq_type : 5;
+
+  // We have six bits left over if someone can come up with a good use for them.
+  uint16_t reserved_bits : 6;
 
   // Line number - we calculate this at capture time because it's fast, and it
   // saves us from storing the iseq.
@@ -210,19 +223,24 @@ typedef struct {
   // If has_cme_method_id is set, this need not be marked, but if it is NOT set,
   // then method_name.base_label needs to be marked.
   union {
-    // Comes from callable_method_entry->def->original_id
+    // Comes from callable_method_entry->called_id
     ID cme_method_id;
     // Comes from iseq->body->location.base_label
     VALUE base_label;
   } method_name;
 
   // VALUE for the filename (abs), or Qnil
-  // Needs to be marked if not Qnil.
+  // Needs to be marked
   VALUE filename;
 
   // See method_qualifier_contents flag for possible values that can be in here.
-  // Needs to be marked if not Qniil.
-  VALUE method_qualifier;
+  // Needs to be marked
+  union {
+    VALUE self;              // the VALUE the method was called on
+    VALUE self_class;        // rb_class_of(the VALUE the method was called on)
+    VALUE cme_defined_class; // the class that the callable_method_entry is
+                             // defined on
+  } method_qualifier;
 } minimal_location_t;
 
 // This is like backtracie_capture_frame_for_thread, but captures a

--- a/ext/backtracie_native_extension/public/backtracie.h
+++ b/ext/backtracie_native_extension/public/backtracie.h
@@ -187,11 +187,15 @@ int *backtracie_frame_wrapper_len(VALUE wrapper);
 // These values define union descriminator values for minimal_location_t.
 // It's tempting to make this an enum, but apparently an enum in a bitfield is
 // implementation-defined behaviour.
-static const uint16_t BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF = 0;
-static const uint16_t BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF_CLASS = 1;
-static const uint16_t BACKTRACIE_METHOD_QUALIFIER_CONTENTS_CME_CLASS = 2;
-static const uint16_t BACKTRACIE_METHOD_NAME_CONTENTS_CME_ID = 0;
-static const uint16_t BACKTRACIE_METHOD_NAME_CONTENTS_BASE_LABEL = 1;
+// It would also be tempting to define these as "const uint16_t", but the
+// ancient version of mingw used to build for Ruby 2.3 on Windows doesn't like
+// using such a constant in a switch statement somehow (??).
+// So... #define's it is.
+#define BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF 0u
+#define BACKTRACIE_METHOD_QUALIFIER_CONTENTS_SELF_CLASS 1u
+#define BACKTRACIE_METHOD_QUALIFIER_CONTENTS_CME_CLASS 2u
+#define BACKTRACIE_METHOD_NAME_CONTENTS_CME_ID 0u
+#define BACKTRACIE_METHOD_NAME_CONTENTS_BASE_LABEL 1u
 
 typedef struct {
   // 1 -> ruby frame / 0 -> cfunc frame


### PR DESCRIPTION
This works by capturing only the things actually needed to convert a
given frame to a string, so that GC marking the location does not
needlessly retain a huge pile of unrelated memory.