### PR TITLE
Fix ruby-head (3.2) builds being broken due to renamed iseq_type enum

### DIFF
--- a/ext/backtracie_native_extension/backtracie_frames.c
+++ b/ext/backtracie_native_extension/backtracie_frames.c
@@ -139,6 +139,13 @@
 #include "public/backtracie.h"
 #include "strbuilder.h"
 
+#ifndef PRE_RB_ISEQ_TYPE
+// This was renamed for Ruby >= 3.2
+  #define RB_ISEQ_TYPE rb_iseq_type
+#else
+  #define RB_ISEQ_TYPE iseq_type
+#endif
+
 #ifdef PRE_EXECUTION_CONTEXT
 // The thread and its execution context were separated on Ruby 2.5; prior to
 // that, everything was part of the thread
@@ -205,11 +212,11 @@ static bool object_has_special_bt_handling(VALUE obj) {
   return obj == backtracie_main_object_instance || obj == rb_mRubyVMFrozenCore;
 }
 
-static bool iseq_type_is_block_or_eval(enum iseq_type type) {
+static bool iseq_type_is_block_or_eval(enum RB_ISEQ_TYPE type) {
   return type == ISEQ_TYPE_EVAL || type == ISEQ_TYPE_BLOCK;
 }
 
-static bool iseq_type_is_eval(enum iseq_type type) {
+static bool iseq_type_is_eval(enum RB_ISEQ_TYPE type) {
   return type == ISEQ_TYPE_EVAL;
 }
 

--- a/ext/backtracie_native_extension/extconf.rb
+++ b/ext/backtracie_native_extension/extconf.rb
@@ -42,6 +42,8 @@ $CFLAGS << ' ' << '-Werror-implicit-function-declaration'
 # NSIG is expected to be defined in signal.h.
 $CFLAGS << ' ' << '-std=gnu99' if RUBY_VERSION < '2.4'
 
+$CFLAGS << ' ' << '-DPRE_RB_ISEQ_TYPE' if RUBY_VERSION < '3.2'
+
 $CFLAGS << ' ' << '-DPRE_GC_MARK_MOVABLE' if RUBY_VERSION < '2.7'
 
 # Older Rubies don't have the MJIT header, see below for details


### PR DESCRIPTION
The rename was done in <https://github.com/ruby/ruby/pull/6169>.

Like with other such compatibility fixes, I've introduced a new define set by extconf.rb.

Fixes #10